### PR TITLE
Added note on FR245

### DIFF
--- a/docs/device-compatibility.md
+++ b/docs/device-compatibility.md
@@ -7,7 +7,7 @@
 | Garmin | FR945 | Watch | Yes |   |   |
 | Garmin | Venu, Insight | Watch | No |   | These watches do not support reading power data from *any* manufacturer but speed and cadence should work |
 | Garmin | Vivoactive 4 | Watch | No | Yes | These watches do not support reading power data from *any* manufacturer but speed and cadence should work |
-| Garmin | FR645 | Watch | No |   | These watches do not support reading power data from *any* manufacturer but speed and cadence should work |
+| Garmin | FR645, FR245 | Watch | No |   | These watches do not support reading power data from *any* manufacturer but speed and cadence should work |
 | Polar | Grit X, Vantage | Watch | Yes |   |   |
 | Cronos | Pace | Watch | Yes |   |   |
 | Garmin | Edge 130, 530, 830 | Cycling Computer | Yes | Yes |   |


### PR DESCRIPTION
FR245 does not pick up power metrics, as the watch does not support reading power data. The FR245 can broadcast heart rate to the Edge 530, which can support power & cadence.

Thank you for developing this device! 